### PR TITLE
Tear down script bug fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       dist: xenial
     - os: osx
       osx_image: xcode11
-
+ 
 env:
   global:
     - BACKUP="$HOME/.rm_backup"

--- a/tear_down.sh
+++ b/tear_down.sh
@@ -22,12 +22,12 @@ else
     exit 1;
 fi
 
-occurences=$(grep -o "rm ()" $HOME/.$os_type | wc -l)
+occurences=$(grep -o "rm ()" $HOME/.$bash_file_type | wc -l)
 if [ $((occurences)) -eq 1 ]; then
-    line_number=$(grep -nr "rm ()" $HOME/.$os_type | cut -d: -f1)
+    line_number=$(grep -nr "rm ()" $HOME/.$bash_file_type | cut -d: -f1)
     sed -i $line_number'd' $HOME/.bashrc
 elif [ $((occurences)) -gt 1 ]; then
-    echo "Your .$os_type is littered with rm () aliases, please clean up."
+    echo "Your .$bash_file_type is littered with rm () aliases, please clean up."
     exit 1
 fi
 if [ -d $HOME/.rm_backup ]; then /bin/rm -rf $HOME/.rm_backup; fi


### PR DESCRIPTION
There was a bug with the tear down script. The wrong variable was used to determine which type of bash variable you would have.